### PR TITLE
Improve IDL file syntax and README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,25 @@
 
 Etymology: tessie sounds better than TC (box), for temperature cycling (box)
 
+## hints for starting with test0
 
-## hints for starting with test0:
+```shell
 git clone git@github.com:ursl/tessie
-
 (git clone https://github.com/ursl/tessie.git)
-
 cd tessie/test0/rpc
-
 make mini
-
 cd ../
-
 qmake -o Makefile test0.pro
-
 make
+```
 
+## RPC communication
 
-## RPC communication 
 works from MAC and/or linux to raspberry pi (tessie.psi.ch)
 
+```shell
 cd rpc
-
 make all
-
 ./trpc_client tessie settemp 17
-
 ./trpc_client tessie gettemp
-
+```

--- a/test0/rpc/trpc.x
+++ b/test0/rpc/trpc.x
@@ -7,10 +7,10 @@ struct args{
 };
 
 /*Programme, version and procedure definition*/
-program TRPC{
-    version TRPC_VERS{
-        void SETTEMP(args)=1;
-        float GETTEMP()=2;
-    } =6;
+program TRPC {
+    version TRPC_VERS {
+        void SETTEMP(args) = 1;
+        float GETTEMP(void) = 2;
+    } = 6;
 
 } = 456123789;


### PR DESCRIPTION
The parser I'm using needs `void` as parameter for `GETTEMP`. The rest of the changes are cosmetics.